### PR TITLE
Llvm 3.4 static inline

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -127,7 +127,8 @@ Decl* C2FFIASTConsumer::make_decl(const clang::FunctionDecl *d, bool is_toplevel
     FunctionDecl *fd = new FunctionDecl(d->getDeclName().getAsString(),
                                         Type::make_type(this, return_type),
                                         d->isVariadic(),
-                                        d->isInlineSpecified());
+                                        d->isInlineSpecified(),
+                                        d->getStorageClass());
 
     for(clang::FunctionDecl::param_const_iterator i = d->param_begin();
         i != d->param_end(); i++) {

--- a/src/Decl.cpp
+++ b/src/Decl.cpp
@@ -86,7 +86,8 @@ void FunctionsMixin::add_functions(C2FFIASTConsumer *ast, const clang::ObjCConta
         const clang::Type *return_type = m->getResultType().getTypePtr();
         FunctionDecl *fd = new FunctionDecl(m->getDeclName().getAsString(),
                                             Type::make_type(ast, return_type),
-                                            m->isVariadic(), false);
+                                            m->isVariadic(), false,
+                                            clang::SC_None);
 
         fd->set_is_objc_method(true);
         fd->set_is_class_method(m->isClassMethod());

--- a/src/drivers/JSON.cpp
+++ b/src/drivers/JSON.cpp
@@ -230,12 +230,21 @@ namespace c2ffi {
         virtual void write(const FunctionDecl &d) {
             const char *variadic = d.is_variadic() ? "true" : "false";
             const char *inline_ = d.is_inline() ? "true" : "false";
+            clang::StorageClass sc = d.storage_class();
+            // According to http://clang.llvm.org/doxygen/Specifiers_8h_source.html#l00170 ,
+            // only these are valid for functions.
+            static const char *sc2str[] = {"\"none\"", "\"extern\"", "\"static\"",
+                "\"private_extern\""};
+            const char *sc_name = "<unknown>";
+            if (sc < sizeof(sc2str) / sizeof(*sc2str))
+                sc_name = sc2str[sc];
 
             write_object("function", 1, 0,
                          "name", qstr(d.name()).c_str(),
                          "location", qstr(d.location()).c_str(),
                          "variadic", variadic,
                          "inline", inline_,
+                         "storage_class", sc_name,
                          NULL);
 
             if(d.is_objc_method())

--- a/src/include/c2ffi/decl.h
+++ b/src/include/c2ffi/decl.h
@@ -116,11 +116,14 @@ namespace c2ffi {
         Type *_return;
         bool _is_variadic;
         bool _is_inline;
+        clang::StorageClass _storage_class;
         bool _is_objc_method;
         bool _is_class_method;
     public:
-        FunctionDecl(std::string name, Type *type, bool is_variadic, bool is_inline)
+        FunctionDecl(std::string name, Type *type, bool is_variadic, bool is_inline,
+                     clang::StorageClass storage_class)
             : Decl(name), _return(type), _is_variadic(is_variadic), _is_inline(is_inline),
+              _storage_class(storage_class),
               _is_class_method(false), _is_objc_method(false) { }
 
         virtual void write(OutputDriver &od) const { od.write((const FunctionDecl&)*this); }
@@ -129,6 +132,7 @@ namespace c2ffi {
 
         bool is_variadic() const { return _is_variadic; }
         bool is_inline() const { return _is_inline; }
+        clang::StorageClass storage_class() const { return _storage_class; }
         bool is_objc_method() const { return _is_objc_method; }
         void set_is_objc_method(bool val) {
             _is_objc_method = val;


### PR DESCRIPTION
Primary motivation is (so far) to detect static inline functions - these are not exported from shared libs, but may be in headers, and then when generating FFI bindings, these should not be blindly imported from shared lib (occurred with libusb.h).
