### PR TITLE
Hack to make NAN values at least be valid JSON

### DIFF
--- a/src/drivers/JSON.cpp
+++ b/src/drivers/JSON.cpp
@@ -307,7 +307,9 @@ namespace c2ffi {
             write(d.type());
 
             if(d.value() != "") {
-                if(d.is_string() || d.value() == "inf")
+                if(d.is_string()
+                    || d.value() == "inf"
+                    || d.value() == "nan")
                     write_object("", 0, 0,
                                  "value", qstr(d.value()).c_str(),
                                  NULL);


### PR DESCRIPTION
See 30436b8c92e58ec7fa2db8fc3742d702d2b99888 for handling of inf being identical

Fixes https://github.com/rpav/c2ffi/issues/49