### PR TITLE
Add INF handling in addition to inf

### DIFF
--- a/src/drivers/JSON.cpp
+++ b/src/drivers/JSON.cpp
@@ -309,6 +309,7 @@ namespace c2ffi {
             if(d.value() != "") {
                 if(d.is_string()
                     || d.value() == "inf"
+                    || d.value() == "INF"
                     || d.value() == "nan")
                     write_object("", 0, 0,
                                  "value", qstr(d.value()).c_str(),


### PR DESCRIPTION
Clang 8 float.h seems to use uppercase INF