### PR TITLE
Fix CLANG and LLVM libraries not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,15 @@ target_include_directories(c2ffi PUBLIC
   ${LLVM_INCLUDE_DIRS}
   ${SOURCE_ROOT}/src/include
   )
+target_link_directories(c2ffi PUBLIC
+  ${LLVM_LIBRARY_DIRS}
+)
+message(STATUS "LLVM_LIBRARY_DIRS=${LLVM_LIBRARY_DIRS}")
+
+llvm_map_components_to_libnames(llvm_libs core support mcparser bitreader profiledata)
+
+message(STATUS "llvm_libs=${llvm_libs}")
+
 target_link_libraries(c2ffi PUBLIC
   clangFrontendTool
   clangFrontend
@@ -64,9 +73,8 @@ target_link_libraries(c2ffi PUBLIC
   clangIndex
   clangToolingCore
   clangTooling
+  ${llvm_libs}
   )
-
-llvm_config(c2ffi USE_SHARED core support mcparser bitreader profiledata)
 
 set(APP_BIN_DIR "${CMAKE_BINARY_DIR}/bin")
 set_target_properties(c2ffi PROPERTIES


### PR DESCRIPTION
This commit gets the build working again here on Gentoo.

Adding LLVM_LIBRARY_DIRS fixes the CLANG libs not found error.

Adding llvm_map_components_to_libnames fixes LLMV not found error.