### PR TITLE
New options for controlling error handling

### DIFF
--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -107,5 +107,7 @@ int main(int argc, char *argv[]) {
     ci.getDiagnosticClient().EndSourceFile();
     sys.output->flush();
 
+    if(sys.fail_on_error && ci.getDiagnostics().hasErrorOccurred())
+        return 1;
     return 0;
 }

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -59,6 +59,8 @@ namespace c2ffi {
 
         bool preprocess_only;
         bool with_macro_defs;
+        bool fail_on_error;
+        bool warn_as_error;
     };
 
     void process_args(config &config, int argc, char *argv[]);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -93,6 +93,9 @@ void c2ffi::init_ci(config &c, clang::CompilerInstance &ci) {
         new TextDiagnosticPrinter(llvm::errs(), dopt, false);
     ci.createDiagnostics(tpd);
 
+    if(c.warn_as_error)
+        ci.getDiagnostics().setWarningsAsErrors(true);
+
     auto pto = std::make_shared<TargetOptions>();
     if(c.arch.empty())
         pto->Triple = llvm::sys::getDefaultTargetTriple();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,6 +33,8 @@ static char short_opt[] = "I:i:D:M:o:hN:x:A:T:E";
 
 enum {
     WITH_MACRO_DEFS = CHAR_MAX+1,
+    FAIL_ON_ERROR   = CHAR_MAX+3,
+    WARN_AS_ERROR   = CHAR_MAX+4,
 };
 
 static struct option options[] = {
@@ -48,6 +50,8 @@ static struct option options[] = {
     { "templates",   required_argument, 0, 'T' },
     { "std",         required_argument, 0, 'S' },
     { "with-macro-defs", no_argument,   0, WITH_MACRO_DEFS },
+    { "fail-on-error", no_argument,     0, FAIL_ON_ERROR   },
+    { "warn-as-error", no_argument,     0, WARN_AS_ERROR   },
     { 0, 0, 0, 0 }
 };
 
@@ -184,6 +188,14 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
                 config.with_macro_defs = true;
                 break;
 
+            case FAIL_ON_ERROR:
+                config.fail_on_error = true;
+                break;
+
+            case WARN_AS_ERROR:
+                config.warn_as_error = true;
+                break;
+
             case 'h':
                 usage();
                 exit(0);
@@ -250,6 +262,9 @@ void usage(void) {
         "      --std                Specify the standard (c99, c++0x, c++11, ...)\n"
         "\n"
         "      -E                   Preprocessed output only, a la clang -E\n"
+        "\n"
+        "      --fail-on-error      Fail command if any compilation error occurs\n"
+        "      --warn-as-error      Treat warnings as errors\n"
         "\n"
         "Drivers: ";
 


### PR DESCRIPTION
Before this change, c2ffi command would return a successful exit code even if compilation errors occurred. Add a new option `--fail-on-error` which causes c2ffi to report a failure exit code if any compilation error occurs. To maintain backwards compatibility, the current behaviour is maintained unchanged when the option is not supplied.

This can be useful when c2ffi is invoked in build scripts, so the build is aborted if an error unexpectedly occurs. While errors can be detected by parsing stderr, it is far easier to be able to just look at the return code.

Also add `--warn-as-error` option which tells clang to treat all warnings as errors. This is the equivalent of passing `-Werror` on the clang command line.

Fixes #20 