### PR TITLE
Adds support for the C99 _Complex types

### DIFF
--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -187,6 +187,10 @@ Type* Type::make_type(C2FFIASTConsumer *ast, const clang::Type *t) {
     if_const_cast(ob, clang::ObjCObjectType, t)
         return new SimpleType(ci, t, ob->getInterface()->getDeclName().getAsString());
 
+    if_const_cast(cx, clang::ComplexType, t)
+        return new ComplexType(ci, cx,
+                               make_type(ast, cx->getElementType().getTypePtr()));
+
  error:
     return new SimpleType(ci, t, std::string("<unknown-type:") +
                           t->getTypeClassName() + ">");

--- a/src/drivers/JSON.cpp
+++ b/src/drivers/JSON.cpp
@@ -284,6 +284,13 @@ namespace c2ffi {
                          NULL);
         }
 
+        virtual void write(const ComplexType &t) {
+            write_object(":complex", 1, 0,
+                         "type", NULL);
+            write(t.element());
+            write_object("", 0, 1, NULL);
+        }
+
         // Decls -----------------------------------------------------------
         virtual void write(const UnhandledDecl &d) {
             write_object("unhandled", 1, 1,

--- a/src/drivers/Null.cpp
+++ b/src/drivers/Null.cpp
@@ -43,6 +43,7 @@ namespace c2ffi {
         virtual void write(const ArrayType &t) { }
         virtual void write(const RecordType &t) { }
         virtual void write(const EnumType &t) { }
+        virtual void write(const ComplexType& t) { }
 
         // Decls -----------------------------------------------------------
         virtual void write(const UnhandledDecl &d) { }

--- a/src/drivers/Sexp.cpp
+++ b/src/drivers/Sexp.cpp
@@ -155,6 +155,14 @@ namespace c2ffi {
             os() << ")";
         }
 
+        virtual void write(const ComplexType& t) {
+            _level++;
+            this->os() << "(:complex ";
+            this->write(t.element());
+            this->os() << ")";
+            _level--;
+        }
+
         // Decls -----------------------------------------------------------
         virtual void write(const UnhandledDecl &d) {
             _level++;

--- a/src/include/c2ffi.h
+++ b/src/include/c2ffi.h
@@ -68,6 +68,7 @@ namespace c2ffi {
         virtual void write(const EnumType&) = 0;
         virtual void write(const ReferenceType&) { }
         virtual void write(const TemplateType&) { }
+        virtual void write(const ComplexType&) = 0;
 
         virtual void write(const UnhandledDecl &d) = 0;
         virtual void write(const VarDecl &d) = 0;

--- a/src/include/c2ffi/predecl.h
+++ b/src/include/c2ffi/predecl.h
@@ -31,6 +31,7 @@ namespace c2ffi {
     class ArrayType;
     class RecordType;
     class EnumType;
+    class ComplexType;
     class DeclType;
     class ReferenceType;
     class TemplateType;

--- a/src/include/c2ffi/type.h
+++ b/src/include/c2ffi/type.h
@@ -173,6 +173,20 @@ namespace c2ffi {
         DEFWRITER(EnumType);
     };
 
+    class ComplexType : public Type {
+        Type *_element;
+    public:
+        ComplexType(const clang::CompilerInstance &ci, const clang::Type *t,
+                    Type *element)
+            : Type(ci, t), _element(element) { }
+        virtual ~ComplexType() { delete _element; }
+
+        const Type& element() const { return *_element; }
+        bool is_string() const;
+
+        DEFWRITER(ComplexType);
+    };
+
     // This is a bit of a hack to contain inline declarations (e.g.,
     // anonymous typedef struct)
     class DeclType : public Type {


### PR DESCRIPTION
C99 adds three floating point complex number types, `float _Complex`, `double _Complex` and `long double _Complex`. Prior to this change, they were all returned as `<unknown-type:Complex>`. Now, they are returned as
(in S-expression format) `:complex :float`, `:complex :double`, etc.

Fixes #74 

Consider this input:

```
struct foo {
  float _Complex e_complex_float;
  double _Complex e_complex_double;
  long double _Complex e_complex_long_double;
};
```

With this change, it will generate this S-expression output:
```
(struct foo
  (e_complex_float (:complex :float))
  (e_complex_double (:complex :double))
  (e_complex_long_double (:complex :long-double)))
```

I won't reproduce the whole JSON here, but this is a relevant extract:
```
{
  "tag": "field",
  "name": "e_complex_long_double",
  "bit-offset": 256,
  "bit-size": 256,
  "bit-alignment": 128,
  "type": {
    "tag": ":complex",
    "type": {
      "tag": ":long-double",
      "bit-size": 128,
      "bit-alignment": 128
    }
  }
}
```

Note the ISO C99 standard only defines floating point complex types, not integer. There is a GCC extension for integer complex types, e.g. `long _Complex`, which is also implemented by Clang. This PR doesn't add any support for integer complex types, but that could always be addressed in the future.