### PR TITLE
New --nostdinc option

### DIFF
--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -56,12 +56,14 @@ int main(int argc, char *argv[]) {
     process_args(sys, argc, argv);
     init_ci(sys, ci);
 
-    add_include(ci, "/usr/local/include", true);
-    add_include(ci, "/usr/lib/clang/" CLANG_VERSION_STRING "/include", true);
-    add_include(ci, "/usr/include/clang/" CLANG_VERSION_STRING "/include", true);
-    add_include(ci, "/usr/local/lib/clang/" CLANG_VERSION_STRING "/include", true);
-    add_include(ci, "/opt/llvm/lib/clang/" CLANG_VERSION_STRING "/include", true);
-    add_include(ci, "/usr/include", true);
+    if(!sys.nostdinc) {
+        add_include(ci, "/usr/local/include", true);
+        add_include(ci, "/usr/lib/clang/" CLANG_VERSION_STRING "/include", true);
+        add_include(ci, "/usr/include/clang/" CLANG_VERSION_STRING "/include", true);
+        add_include(ci, "/usr/local/lib/clang/" CLANG_VERSION_STRING "/include", true);
+        add_include(ci, "/opt/llvm/lib/clang/" CLANG_VERSION_STRING "/include", true);
+        add_include(ci, "/usr/include", true);
+    }
 
     add_includes(ci, sys.includes, false, true);
     add_includes(ci, sys.sys_includes, true, true);

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -59,6 +59,7 @@ namespace c2ffi {
 
         bool preprocess_only;
         bool with_macro_defs;
+        bool nostdinc;
     };
 
     void process_args(config &config, int argc, char *argv[]);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,6 +33,7 @@ static char short_opt[] = "I:i:D:M:o:hN:x:A:T:E";
 
 enum {
     WITH_MACRO_DEFS = CHAR_MAX+1,
+    NOSTDINC        = CHAR_MAX+5
 };
 
 static struct option options[] = {
@@ -48,6 +49,7 @@ static struct option options[] = {
     { "templates",   required_argument, 0, 'T' },
     { "std",         required_argument, 0, 'S' },
     { "with-macro-defs", no_argument,   0, WITH_MACRO_DEFS },
+    { "nostdinc",    no_argument,       0, NOSTDINC        },
     { 0, 0, 0, 0 }
 };
 
@@ -184,6 +186,10 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
                 config.with_macro_defs = true;
                 break;
 
+            case NOSTDINC:
+                config.nostdinc = true;
+                break;
+
             case 'h':
                 usage();
                 exit(0);
@@ -234,6 +240,7 @@ void usage(void) {
         "Options:\n"
         "      -I, --include        Add a \"LOCAL\" include path\n"
         "      -i, --sys-include    Add a <system> include path\n"
+        "      --nostdinc           Disable standard include path\n"
         "      -D, --driver         Specify an output driver (default: "
          << OutputDrivers[0].name << ")\n"
         "\n"


### PR DESCRIPTION
With this option, standard header files such as /usr/include are not included in the search path. This necessary if you want to use c2ffi in a cross-compilation scenario, e.g. processing Windows headers while running on Linux. Without this, it will mix the local platform headers with the foreign platform headers, which is an invalid combination which has a high likelihood of resulting in an error.

This new `--nostdinc` option to c2ffi is approximately equivalent to passing the `-nostdinc` option on the clang command line.