### PR TITLE
Add support for wide string literals in macros

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -37,9 +37,11 @@
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Parse/ParseAST.h>
 #include <clang/Parse/Parser.h>
+#include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/ConvertUTF.h>
 
 #include "c2ffi.h"
 #include "c2ffi/ast.h"
@@ -219,6 +221,27 @@ Decl* C2FFIASTConsumer::make_decl(const clang::FunctionDecl* d, bool is_toplevel
     return fd;
 }
 
+static bool convertUTF32ToUTF8String(const llvm::ArrayRef<char> &Source, std::string &Result) {
+    const char*  SourceBegins = Source.data();
+    const size_t SourceLength = Source.size();
+    const char*  SourceEnding = SourceBegins + SourceLength;
+    const size_t ResultMaxLen = SourceLength * UNI_MAX_UTF8_BYTES_PER_CODE_POINT;
+    Result.resize(ResultMaxLen);
+    const llvm::UTF32* SourceBeginsUTF32 = reinterpret_cast<const llvm::UTF32*>(SourceBegins);
+    const llvm::UTF32* SourceEndingUTF32 = reinterpret_cast<const llvm::UTF32*>(SourceEnding);
+    llvm::UTF8* ResultBeginsUTF8 = reinterpret_cast<llvm::UTF8*>(&Result[0]);
+    llvm::UTF8* ResultEndingUTF8 = reinterpret_cast<llvm::UTF8*>(&Result[0] + ResultMaxLen);
+    const llvm::ConversionResult CR = llvm::ConvertUTF32toUTF8(&SourceBeginsUTF32, SourceEndingUTF32,
+                                                               &ResultBeginsUTF8, ResultEndingUTF8,
+                                                               llvm::strictConversion);
+    if (CR != llvm::conversionOK) {
+        Result.clear();
+        return false;
+    }
+    Result.resize(reinterpret_cast<char*>(ResultEndingUTF8) - &Result[0]);
+    return true;
+}
+
 Decl* C2FFIASTConsumer::make_decl(const clang::VarDecl* d, bool is_toplevel)
 {
     clang::APValue*    v         = NULL;
@@ -253,6 +276,12 @@ Decl* C2FFIASTConsumer::make_decl(const clang::VarDecl* d, bool is_toplevel)
 
                             if(s->isAscii() || s->isUTF8()) {
                                 value = s->getString();
+                            } else if(s->getCharByteWidth() == 2) {
+                                llvm::StringRef bytes = s->getBytes();
+                                llvm::convertUTF16ToUTF8String(llvm::ArrayRef<char>(bytes.data(), bytes.size()), value);
+                            } else if(s->getCharByteWidth() == 4) {
+                                llvm::StringRef bytes = s->getBytes();
+                                convertUTF32ToUTF8String(llvm::ArrayRef<char>(bytes.data(), bytes.size()), value);
                             } else {
                             }
                         }

--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -44,7 +44,8 @@ enum best_guess {
     tok_long_long,
     tok_unsigned_long_long,
     tok_float,
-    tok_string
+    tok_string,
+    tok_wide_string
 };
 
 static best_guess macro_type(
@@ -116,6 +117,8 @@ static best_guess macro_type(
                 guess = num_type(ci, t);
             else if(t.getKind() == clang::tok::string_literal)
                 guess = tok_string;
+            else if(t.getKind() == clang::tok::wide_string_literal)
+                guess = tok_wide_string;
             else if(
                 t.getKind() == clang::tok::char_constant || t.getKind() == clang::tok::wide_char_constant
                 || t.getKind() == clang::tok::utf16_char_constant || t.getKind() == clang::tok::utf32_char_constant)
@@ -177,6 +180,7 @@ static void output_redef(
         case tok_unsigned: os << "unsigned long"; break;
         case tok_int: os << "long"; break;
         case tok_float: os << "double"; break;
+        case tok_wide_string: os << "__WCHAR_TYPE__*"; break;
         case tok_string:
         default: os << "char*"; break;
     }

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -39,7 +39,8 @@ namespace c2ffi {
                    template_output(NULL),
                    std(clang::LangStandard::lang_unspecified),
                    preprocess_only(false),
-                   with_macro_defs(false)
+                   with_macro_defs(false),
+                   wchar_size(0)
         { }
 
         IncludeVector includes;
@@ -59,6 +60,8 @@ namespace c2ffi {
 
         bool preprocess_only;
         bool with_macro_defs;
+
+        int wchar_size;
     };
 
     void process_args(config &config, int argc, char *argv[]);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -117,6 +117,9 @@ void c2ffi::init_ci(config &c, clang::CompilerInstance &ci) {
                       << "'" << std::endl;
     }
 
+    if(c.wchar_size != 0)
+        lo.WCharSize = c.wchar_size;
+
     clang::PreprocessorOptions preopts;
     ci.getInvocation().setLangDefaults(lo, c.kind, pti->getTriple(), preopts, c.std);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,6 +33,7 @@ static char short_opt[] = "I:i:D:M:o:hN:x:A:T:E";
 
 enum {
     WITH_MACRO_DEFS = CHAR_MAX+1,
+    WCHAR_SIZE      = CHAR_MAX+6,
 };
 
 static struct option options[] = {
@@ -48,6 +49,7 @@ static struct option options[] = {
     { "templates",   required_argument, 0, 'T' },
     { "std",         required_argument, 0, 'S' },
     { "with-macro-defs", no_argument,   0, WITH_MACRO_DEFS },
+    { "wchar-size",  required_argument, 0, WCHAR_SIZE      },
     { 0, 0, 0, 0 }
 };
 
@@ -184,6 +186,19 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
                 config.with_macro_defs = true;
                 break;
 
+            case WCHAR_SIZE:
+                if(config.wchar_size != 0) {
+                    std::cerr << "Error: duplicate argument, --wchar-size=" << optarg << std::endl;
+                    exit(1);
+                }
+                if(strlen(optarg) == 1 && (optarg[0] == '1' || optarg[0] == '2' || optarg[0] == '4'))
+                    config.wchar_size = optarg[0] - '0';
+                else {
+                    std::cerr << "Error: invalid argument, --wchar-size=" << optarg << std::endl;
+                    exit(1);
+                }
+                break;
+
             case 'h':
                 usage();
                 exit(0);
@@ -248,6 +263,7 @@ void usage(void) {
          << llvm::sys::getDefaultTargetTriple() << ")\n"
         "      -x, --lang           Specify language (c, c++, objc, objc++)\n"
         "      --std                Specify the standard (c99, c++0x, c++11, ...)\n"
+        "      --wchar-size=N       Specify wchar_t size (N must be 1, 2, or 4)\n"
         "\n"
         "      -E                   Preprocessed output only, a la clang -E\n"
         "\n"


### PR DESCRIPTION
The macro handling code doesn't recognise wide string literals.

As a result, it guesses them as type `const char*` instead of the correct type `const wchar_t*`.

As an example, the Windows SDK `<security.h>` header file contains:
```
 #define MICROSOFT_KERBEROS_NAME_W   L"Kerberos"
```

The `L"..."` is syntax for a wide character string literal, of type `wchar_t*`.

This is very common syntax in Windows header files. On other platforms such as macOS and Linux, it is still valid C syntax but rather rarely used in practice. Those platforms prefer to use UTF-8 for Unicode string storage, which means that the traditional narrow-string `char*` suffices.

Note that this PR doesn't actually use `wchar_t`, instead it uses `__WCHAR_TYPE__`. That's a predefined macro which Clang (and GCC) define as the actual integer type being used as the wide character type (short or int or long). I did this because `wchar_t` is a typedef which is only defined if you include `<wchar.h>`, which (in Clang and GCC) defines it as `typedef __WCHAR_TYPE__ wchar_t;`. By using `__WCHAR_TYPE__` instead of `wchar_t`, it works even if you didn't include `<wchar.h>`.

This PR fixes c2ffi so it guesses the type of the literal correctly in this case.

It also adds the necessary code to include the value of the JSON string literal in the JSON or s-expression output. Clang stores wide strings in memory either as UTF-16 or UTF-32, so we need to convert the wide string value to UTF-8 for output.

Also add a new option --wchar-size=N which can be used to control the size of wchar_t, supported values are either 1, 2 or 4 bytes. This is equivalent to passing the `-fwchar-type` option to Clang with an argument of either `char`, `short` or `int` (respectively).