### PR TITLE
Adds CI using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 name: Build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+on: push
+
+name: Build
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        run: |
+          docker build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(c2ffi)
 set(SOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
 find_package(LLVM 11.0 REQUIRED CONFIG)
+find_package(Clang)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "LLVM installed in ${LLVM_INSTALL_PREFIX}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Using Ubuntu 20.04 seems to be simplest way to get an LLVM-11 that works
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y llvm-11 clang-11 libclang-11-dev libclang-cpp11-dev python3-pip
+
+# Easiest way to get sufficiently new cmake appears to be using pip - Ubuntu 20.04 version is too old
+RUN pip3 install --upgrade cmake
+
+# Copy the source into the Docker container
+RUN mkdir -p /c2ffi
+COPY / /c2ffi
+WORKDIR /c2ffi
+
+# Build c2ffi
+RUN cd /c2ffi && \
+        rm -rf build && mkdir -p build && cd build && \
+        cmake .. && make
+
+# As a sanity check, make sure the binary we built can be executed
+RUN /c2ffi/build/bin/c2ffi --help


### PR DESCRIPTION
This can be used to check PRs build correctly.

I used Ubuntu 20.04 because that appeared to be the easiest way to get a working LLVM 11.

The build is performed in a Docker container to provide better isolation from GitHub's environment. Although GitHub provides VMs for Ubuntu 20.04, they preinstall LLVM 8 in their VMs which causes confusion. By using Docker, we hide any tools GitHub may have preinstalled into the VM and get more control over the build environment.

Also we need to add `find_package(Clang)` to CMakeLists.txt, otherwise linking the binary fails with `/usr/bin/ld: cannot find -lclang-cpp`

You can see the output of running it here: https://github.com/skissane/c2ffi/actions/runs/498702587