### PR TITLE
Add macOS 10.15 build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ on: [push, pull_request]
 name: Build
 
 jobs:
-  build:
-    name: Build
+  build-linux:
+    name: Build Linux
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -15,3 +15,17 @@ jobs:
       - name: Build Archlinux
         run: |
           docker build -f Docker/Test-Build-Archlinux.docker .
+  build-macos-10_15:
+    name: Build macOS 10.15
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build macOS 10.15
+        run: |
+          mkdir build
+          cd build
+          export PATH="$(brew --prefix llvm)/bin:$PATH"
+          cmake -DTOOLCHAIN=gcc -DBUILD_CONFIG=Release ..
+          make
+          ./bin/c2ffi --help

--- a/CMake/cxx_features.cmake
+++ b/CMake/cxx_features.cmake
@@ -40,7 +40,7 @@
 
 cmake_minimum_required(VERSION 3.11)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   if(WIN32 AND NOT MINGW)
     function(__cxx_feature_process)
       __cxx_feature_clang_cl(${ARGN})


### PR DESCRIPTION
Note this build workflow lies a bit - it tells CMake we are building with GCC (`-DTOOLCHAIN=gcc`), but actually on macOS by default `gcc` is a wrapper for AppleClang. I did it this way because it was the simplest way to get it to work. Passing `-DTOOLCHAIN=clang` fails with a bunch of errors due to clang not liking the parameters that CMake is passing.