### PR TITLE
Add --frameworks, --sys-frameworks options

### DIFF
--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -67,6 +67,8 @@ int main(int argc, char *argv[]) {
 
     add_includes(ci, sys.includes, false, true);
     add_includes(ci, sys.sys_includes, true, true);
+    add_includes(ci, sys.frameworks, false, true, true);
+    add_includes(ci, sys.sys_frameworks, true, true, true);
 
     C2FFIASTConsumer *astc = NULL;
 

--- a/src/include/c2ffi/init.h
+++ b/src/include/c2ffi/init.h
@@ -27,10 +27,11 @@
 
 namespace c2ffi {
     void add_include(clang::CompilerInstance &ci, const char *path,
-                     bool isAngled = false, bool show_error = false);
+                     bool isAngled = false, bool show_error = false,
+                     bool is_framework = false);
     void add_includes(clang::CompilerInstance &ci,
                       c2ffi::IncludeVector &v, bool is_angled = false,
-                      bool show_error = false);
+                      bool show_error = false, bool is_framework = false);
 
     void init_ci(config &c, clang::CompilerInstance &ci);
 }

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -46,6 +46,8 @@ namespace c2ffi {
 
         IncludeVector includes;
         IncludeVector sys_includes;
+        IncludeVector frameworks;
+        IncludeVector sys_frameworks;
         OutputDriver *od;
 
         std::ostream  *output;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -55,9 +55,9 @@ void c2ffi::add_include(clang::CompilerInstance &ci, const char *path, bool is_a
         if(show_error) {
             std::cerr << "Error: Not a directory: ";
             if(is_framework && is_angled)
-                std::cerr << "--sys-framework ";
+                std::cerr << "--sys-frameworks ";
             else if(is_framework)
-                std::cerr << "--framework ";
+                std::cerr << "--frameworks ";
             else if(is_angled)
                 std::cerr << "-i ";
             else

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -39,16 +39,16 @@ enum {
     NOSTDINC        = CHAR_MAX+5,
     WCHAR_SIZE      = CHAR_MAX+6,
     ERROR_LIMIT     = CHAR_MAX+7,
-    FRAMEWORK       = CHAR_MAX+8,
-    SYS_FRAMEWORK   = CHAR_MAX+9,
+    FRAMEWORKS       = CHAR_MAX+8,
+    SYS_FRAMEWORKS   = CHAR_MAX+9,
     OPTION_MAX
 };
 
 static struct option options[] = {
     { "include",     required_argument, 0, 'I' },
     { "sys-include", required_argument, 0, 'i' },
-    { "framework",   required_argument, 0, FRAMEWORK },
-    { "sys-framework", required_argument, 0, SYS_FRAMEWORK },
+    { "frameworks",  required_argument, 0, FRAMEWORKS },
+    { "sys-frameworks", required_argument, 0, SYS_FRAMEWORKS },
     { "driver",      required_argument, 0, 'D' },
     { "help",        no_argument,       0, 'h' },
     { "macro-file",  required_argument, 0, 'M' },
@@ -152,11 +152,11 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
                 config.sys_includes.push_back(optarg);
                 break;
 
-            case FRAMEWORK:
+            case FRAMEWORKS:
                 config.frameworks.push_back(optarg);
                 break;
 
-            case SYS_FRAMEWORK:
+            case SYS_FRAMEWORKS:
                 config.sys_frameworks.push_back(optarg);
                 break;
 
@@ -303,8 +303,8 @@ void usage(void) {
         "Options:\n"
         "      -I, --include        Add a \"LOCAL\" include path\n"
         "      -i, --sys-include    Add a <system> include path\n"
-        "      --framework          Add a framework directory to the include path\n"
-        "      --sys-framework      Add a system framework directory to the include path\n"
+        "      --frameworks         Add a framework directory to the include path\n"
+        "      --sys-frameworks     Add a system framework directory to the include path\n"
         "      --nostdinc           Disable standard include path\n"
         "      -D, --driver         Specify an output driver (default: "
          << OutputDrivers[0].name << ")\n"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -39,13 +39,16 @@ enum {
     NOSTDINC        = CHAR_MAX+5,
     WCHAR_SIZE      = CHAR_MAX+6,
     ERROR_LIMIT     = CHAR_MAX+7,
-
+    FRAMEWORK       = CHAR_MAX+8,
+    SYS_FRAMEWORK   = CHAR_MAX+9,
     OPTION_MAX
 };
 
 static struct option options[] = {
     { "include",     required_argument, 0, 'I' },
     { "sys-include", required_argument, 0, 'i' },
+    { "framework",   required_argument, 0, FRAMEWORK },
+    { "sys-framework", required_argument, 0, SYS_FRAMEWORK },
     { "driver",      required_argument, 0, 'D' },
     { "help",        no_argument,       0, 'h' },
     { "macro-file",  required_argument, 0, 'M' },
@@ -147,6 +150,14 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
 
             case 'i':
                 config.sys_includes.push_back(optarg);
+                break;
+
+            case FRAMEWORK:
+                config.frameworks.push_back(optarg);
+                break;
+
+            case SYS_FRAMEWORK:
+                config.sys_frameworks.push_back(optarg);
                 break;
 
             case 'D':
@@ -292,6 +303,8 @@ void usage(void) {
         "Options:\n"
         "      -I, --include        Add a \"LOCAL\" include path\n"
         "      -i, --sys-include    Add a <system> include path\n"
+        "      --framework          Add a framework directory to the include path\n"
+        "      --sys-framework      Add a system framework directory to the include path\n"
         "      --nostdinc           Disable standard include path\n"
         "      -D, --driver         Specify an output driver (default: "
          << OutputDrivers[0].name << ")\n"


### PR DESCRIPTION
These can be used to specify the user and system framework directories. Frameworks are primarily a macOS concept (originally inherited from NeXTSTEP), so these options are likely to be mainly useful on macOS (and other closely related platforms such as iOS).

The most common use case is if you want to process headers for system frameworks provided with macOS. In that case you want to pass something like this:
```
--sys-frameworks $(xcrun --show-sdk-path)/System/Library/Frameworks
```

`--frameworks` is equivalent to the `-F` clang option.

`--sys-frameworks` is equivalent to the `-iframework` clang option.

Note originally I called these options with the singular `framework` not the plural `frameworks`. I switched to the plural because it makes clearer what they actually do. They don't take the directory of a single framework. They take a `Frameworks` directory which has `*.framework` subdirectories. Hence the plural – the `Frameworks` directory can (and usual will) contain more than one framework.