### PR TITLE
Fix ArchLinux CI failure

### DIFF
--- a/Docker/Test-Build-Archlinux.docker
+++ b/Docker/Test-Build-Archlinux.docker
@@ -2,6 +2,20 @@
 FROM archlinux:latest
 RUN pacman --noconfirm -Syu --noconfirm llvm clang cmake make
 
+# Downgrade from LLVM/Clang 11.1.0 to 11.0.1
+RUN cd /tmp && \
+        curl -L -O https://aur.archlinux.org/cgit/aur.git/snapshot/downgrade.tar.gz && \
+        tar xzf downgrade.tar.gz && \
+        cd downgrade && \
+        cp /usr/sbin/makepkg . && \
+        sed -i 's/if (( EUID == 0 )); then/if false; then/' ./makepkg && \
+        pacman --noconfirm -S fakeroot pacman-contrib && \
+        ./makepkg -si --noconfirm && \
+        rm -rf /tmp/downgrade* && \
+        echo "IgnorePkg = llvm" >> /etc/pacman.conf && \
+        echo "IgnorePkg = clang" >> /etc/pacman.conf && \
+        downgrade --ala-only llvm=11.0.1-2 clang=11.0.1-1 -- --noconfirm
+
 # Copy the source into the Docker container
 RUN mkdir -p /c2ffi
 COPY / /c2ffi


### PR DESCRIPTION
CI build fails for ArchLinux because ArchLinux has already upgraded to LLVM 11.1.x but (on this branch at least) we only support LLVM 11.0.x. We forcibly downgrade Arch to LLVM/Clang 11.0.1 to fix that.

ArchLinux is a "rolling release" distribution which tries to release the latest upstream packages as soon as possible. However, that is less than ideal for a CI system, since a new upstream release may unexpectedly break the build, forcing you to immediately attend to that (even if you don't have the bandwidth for it at the moment.) Given ArchLinux's rolling release nature, it makes it hard (but not impossible) to stay on an older release of a package. As you can see here, it is complicated. (Maybe there is a simpler way of doing it; I don't know, my experience with Arch is limited; this is the first thing I found that worked.)