### PR TITLE
Use clang's built-in header search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,30 @@ set(HEADER_FILES
   ${HEADER_GLOB}
   )
 
+# Find Clang resource directory with Clang executable.
+if(NOT CLANG_RESOURCE_DIR)
+    set(CLANG_EXECUTABLE "${CLANG_INSTALL_PREFIX}/bin/clang")
+    if(NOT CLANG_EXECUTABLE)
+        message(FATAL_ERROR "clang executable not found.")
+    endif()
+
+    execute_process(
+        COMMAND ${CLANG_EXECUTABLE} -print-resource-dir
+        RESULT_VARIABLE CLANG_FIND_RESOURCE_DIR_RESULT
+        OUTPUT_VARIABLE CLANG_RESOURCE_DIR
+        ERROR_VARIABLE CLANG_FIND_RESOURCE_DIR_ERROR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+    if(CLANG_FIND_RESOURCE_DIR_RESULT)
+        message(FATAL_ERROR "Error retrieving Clang resource directory with Clang \
+            executable. Output:\n ${CLANG_FIND_RESOURCE_DIR_ERROR}")
+    endif()
+endif()
+
 add_executable(c2ffi ${SOURCE_FILES} ${HEADER_FILES})
+set_property(SOURCE src/init.cpp APPEND PROPERTY COMPILE_DEFINITIONS
+    CLANG_RESOURCE_DIRECTORY=R"\(${CLANG_RESOURCE_DIR}\)")
 target_cxx_std(c2ffi 17)
 target_include_directories(c2ffi PUBLIC
   ${LLVM_INCLUDE_DIRS}

--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -56,15 +56,6 @@ int main(int argc, char *argv[]) {
     process_args(sys, argc, argv);
     init_ci(sys, ci);
 
-    if(!sys.nostdinc) {
-        add_include(ci, "/usr/local/include", true);
-        add_include(ci, "/usr/lib/clang/" CLANG_VERSION_STRING "/include", true);
-        add_include(ci, "/usr/include/clang/" CLANG_VERSION_STRING "/include", true);
-        add_include(ci, "/usr/local/lib/clang/" CLANG_VERSION_STRING "/include", true);
-        add_include(ci, "/opt/llvm/lib/clang/" CLANG_VERSION_STRING "/include", true);
-        add_include(ci, "/usr/include", true);
-    }
-
     add_includes(ci, sys.includes, false, true);
     add_includes(ci, sys.sys_includes, true, true);
 

--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[]) {
     c2ffi::config sys;
 
     process_args(sys, argc, argv);
+    // this finishes parsing the arguments using clang
     init_ci(sys, ci);
 
     add_includes(ci, sys.includes, false, true);

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -53,6 +53,7 @@ namespace c2ffi {
         std::ofstream *macro_output;
         std::ofstream *template_output;
 
+        std::string c2ffi_binpath;
         std::string filename;
         std::string to_namespace;
 

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -58,6 +58,7 @@ namespace c2ffi {
         std::string to_namespace;
 
         clang::InputKind kind;
+        std::string lang;
         clang::LangStandard::Kind std;
         std::string arch;
 

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -40,6 +40,7 @@ namespace c2ffi {
                    std(clang::LangStandard::lang_unspecified),
                    preprocess_only(false),
                    with_macro_defs(false),
+                   nostdinc(false),
                    wchar_size(0),
                    error_limit(-1)
         { }

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -42,7 +42,7 @@ namespace c2ffi {
                    with_macro_defs(false),
                    nostdinc(false),
                    wchar_size(0),
-                   error_limit(-1)
+                   error_limit(0)
         { }
 
         IncludeVector includes;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -135,6 +135,12 @@ void c2ffi::init_ci(config &c, clang::CompilerInstance &ci) {
     ci.setTarget(pti);
     ci.createFileManager();
     ci.createSourceManager(ci.getFileManager());
+    // examples/clang-interpreter/main.cpp
+    // Infer the builtin include path if unspecified.
+    if (!c.nostdinc &&
+        ci.getHeaderSearchOpts().ResourceDir.empty())
+      ci.getHeaderSearchOpts().ResourceDir =
+          clang::CompilerInvocation::GetResourcesPath(c.c2ffi_binpath.c_str(), (void *)init_ci);
     ci.createPreprocessor(clang::TU_Complete);
     ci.getPreprocessorOpts().UsePredefines = false;
     ci.getPreprocessorOutputOpts().ShowCPP = c.preprocess_only;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -37,6 +37,7 @@
 #include <clang/Basic/TargetInfo.h>
 #include <clang/Basic/FileManager.h>
 #include <clang/Basic/SourceManager.h>
+#include <clang/Basic/Builtins.h>
 #include <clang/Lex/HeaderSearch.h>
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Lex/PreprocessorOptions.h>
@@ -209,5 +210,8 @@ void c2ffi::init_ci(config &c, clang::CompilerInstance &ci) {
     ci.createPreprocessor(clang::TU_Complete);
     ci.getPreprocessorOpts().UsePredefines = false;
     ci.getPreprocessorOutputOpts().ShowCPP = c.preprocess_only;
-    ci.getPreprocessor().setPreprocessedOutput(c.preprocess_only);
+    auto &PP = ci.getPreprocessor();
+    PP.setPreprocessedOutput(c.preprocess_only);
+    // FIXME this is normally called from FrontendAction. Perhaps we should use IndexAction?
+    PP.getBuiltinInfo().initializeBuiltins(PP.getIdentifierTable(), PP.getLangOpts());
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -98,6 +98,8 @@ void c2ffi::init_ci(config &c, clang::CompilerInstance &ci) {
     std::vector<const char *> cargs;
     cargs.push_back(c.c2ffi_binpath.c_str());
     cargs.push_back(c.filename.c_str());
+    cargs.push_back("-resource-dir");
+    cargs.push_back(CLANG_RESOURCE_DIRECTORY);
 
     IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
     TextDiagnosticPrinter *tpd =
@@ -163,8 +165,6 @@ void c2ffi::init_ci(config &c, clang::CompilerInstance &ci) {
 
     clang::PreprocessorOptions preopts;
     ci.getInvocation().setLangDefaults(lo, c.kind, pti->getTriple(), preopts, c.std);
-
-    ci.setTarget(pti);
     ci.createFileManager();
     ci.createSourceManager(ci.getFileManager());
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -106,6 +106,7 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
     int o, index;
     bool output_specified = false;
     std::ostream *os = &std::cout;
+    config.c2ffi_binpath = argv[0];
 
     for(;;) {
         o = getopt_long(argc, argv, short_opt, options, &index);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -68,38 +68,10 @@ static struct option options[] = {
 static void usage(void);
 static c2ffi::OutputDriver* select_driver(std::string name, std::ostream *os);
 
-clang::InputKind parseLang(std::string str) {
-    using namespace clang;
-
-    if(str == "c")      return InputKind(Language::C);
-    if(str == "c++")    return InputKind(Language::CXX);
-    if(str == "objc")   return InputKind(Language::ObjC);
-    if(str == "objc++") return InputKind(Language::ObjCXX);
-
-    exit(1);
-}
-
 clang::LangStandard::Kind parseStd(std::string std) {
 #define LANGSTANDARD(ident, name, lang, desc, features) if(std == name) return clang::LangStandard::lang_##ident;
 #include "clang/Basic/LangStandards.def"
     return clang::LangStandard::lang_unspecified;
-}
-
-clang::InputKind parseExtension(std::string file) {
-    using namespace clang;
-
-    std::string ext = file.substr(file.find_last_of('.')+1, std::string::npos);
-
-    if(ext == "c")      return InputKind(Language::C);
-    if(ext == "cpp" ||
-       ext == "cxx" ||
-       ext == "c++" ||
-       ext == "hpp" ||
-       ext == "hxx")    return InputKind(Language::CXX);
-    if(ext == "m")      return InputKind(Language::ObjC);
-    if(ext == "mm")     return InputKind(Language::ObjCXX);
-
-    return InputKind(Language::C);
 }
 
 void c2ffi::process_args(config &config, int argc, char *argv[]) {
@@ -164,7 +136,7 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
                 break;
 
             case 'x':
-                config.kind = parseLang(optarg);
+                config.lang = optarg;
                 break;
 
             case 'A':
@@ -260,8 +232,6 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
         exit(1);
     } else {
         config.filename = std::string(argv[optind++]);
-        if(config.kind.getLanguage() == clang::Language::Unknown)
-            config.kind = parseExtension(config.filename);
     }
 
     struct stat buf;


### PR DESCRIPTION
I think I found the right incantation for this in an example. For me this works without manually specifying the header paths.