### PR TITLE
Use internal buffers for generated macro and template code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,12 @@ if(NOT LLVM_FOUND)
 endif()
 
 
-find_package(Clang)
+find_package(Clang HINTS "${LLVM_INSTALL_PREFIX}")
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "LLVM installed in ${LLVM_INSTALL_PREFIX}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+message(STATUS "Using Clang in: ${CLANG_INSTALL_PREFIX}")
 
 file(GLOB SOURCE_GLOB
   ${SOURCE_ROOT}/src/*.cpp

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Options:
       -D, --driver         Specify an output driver (default: json)
 
       -o, --output         Specify an output file (default: stdout)
-      -M, --macros         Enable generation of constants from macros
+      -M, --macro-file     Enable generation of constants from macros into specified file
+      -m, --macro-append   Enable generation of constants from macros internally appended
+                           to input
       --with-macro-defs    Also include #defines for macro definitions
       -T, --templates      Enable automatic generation of template specializations
 

--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -168,13 +168,9 @@ bool C2FFIASTConsumer::HandleTopLevelDecl(clang::DeclGroupRef d)
     return true;
 }
 
-void C2FFIASTConsumer::PostProcess()
+void C2FFIASTConsumer::PostProcess(std::ostream& out)
 {
     if(!_config.template_output) return;
-
-    std::ofstream& out = *_config.template_output;
-
-    out << "#include \"" << _config.filename << "\"" << std::endl;
 
     for(ClangDeclSet::iterator i = _cxx_decls.begin(); i != _cxx_decls.end(); ++i) {
         const clang::Decl* d = (*i);

--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -88,20 +88,20 @@ static best_guess tok_type(
     tok::TokenKind k = t.getKind();
 
     switch (k) {
-      case tok::identifier: {
-        IdentifierInfo *ii = t.getIdentifierInfo();
-        if (ii && !seen->count(ii->getNameStart()))
-          return macro_type(ci, pp, ii->getNameStart(), pp.getMacroInfo(ii),
-                            seen);
-        break;
-      }
-      // guess that macros with braces are not something we should mess with,
-      // they can cause sections of valid definitions to be ignored.
-      case tok::r_brace:
-      case tok::l_brace:
-        return tok_invalid;
-      default:
-        break;
+        case tok::identifier: {
+            IdentifierInfo *ii = t.getIdentifierInfo();
+            if (ii && !seen->count(ii->getNameStart()))
+                return macro_type(ci, pp, ii->getNameStart(), pp.getMacroInfo(ii),
+                                  seen);
+            break;
+        }
+            // guess that macros with braces are not something we should mess with,
+            // they can cause sections of valid definitions to be ignored.
+        case tok::r_brace:
+        case tok::l_brace:
+            return tok_invalid;
+        default:
+            break;
     }
     return tok_ok;
 }
@@ -181,7 +181,7 @@ static void output_redef(
     using namespace c2ffi;
 
     if (type == tok_invalid) {
-      return;
+        return;
     }
 
     os << "const ";

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -76,7 +76,7 @@ TemplateMixin::TemplateMixin(C2FFIASTConsumer* ast, const clang::TemplateArgumen
 
 void C2FFIASTConsumer::write_template(
     const clang::ClassTemplateSpecializationDecl* d,
-    std::ofstream&                                out)
+    std::ostream&                                 out)
 {
     using namespace std;
 

--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -75,11 +75,7 @@ static void amendFromStream(clang::CompilerInstance &ci,
       ci.getSourceManager().createFileID(std::unique_ptr<llvm::MemoryBuffer>(
           llvm::MemoryBuffer::getMemBuffer(buf, name)));
 
-  ci.getSourceManager().setMainFileID(mfid);
-
-  ci.getDiagnosticClient().BeginSourceFile(ci.getLangOpts(),
-                                           &ci.getPreprocessor());
-  IncrementalParseAST(S, false, true);
+  IncrementalParseAST(S, mfid, false, true);
 }
 
 int main(int argc, char *argv[]) {
@@ -112,7 +108,6 @@ int main(int argc, char *argv[]) {
                                         ci.getPreprocessorOutputOpts());
         delete os;
         main_error = ci.getDiagnostics().hasErrorOccurred();
-        ci.getDiagnosticClient().EndSourceFile();
     } else {
         astc = new C2FFIASTConsumer(ci, sys);
         ci.setASTConsumer(std::unique_ptr<clang::ASTConsumer>(astc));
@@ -132,7 +127,6 @@ int main(int argc, char *argv[]) {
         clang::ParseAST(*S.get(), false, true);
 
         main_error = ci.getDiagnostics().hasErrorOccurred();
-        ci.getDiagnosticClient().EndSourceFile();
         ci.getDiagnostics().Reset();
 
         if (sys.macro_output) {
@@ -150,7 +144,7 @@ int main(int argc, char *argv[]) {
         sys.od->write_footer();
         extra_error = ci.getDiagnostics().hasErrorOccurred();
     }
-
+    ci.getDiagnosticClient().EndSourceFile();
     sys.output->flush();
 
     if(extra_error)

--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -128,10 +128,17 @@ int main(int argc, char *argv[]) {
         main_error = ci.getDiagnostics().hasErrorOccurred();
         ci.getDiagnostics().Reset();
 
-        if (sys.macro_output) {
+        if (sys.macro_output || sys.macro_inject) {
             std::stringstream macros_ss;
             process_macros(ci, macros_ss, sys);
-            amendFromStream(ci, macros_ss, "<macros>", sys, *S.get());
+            if (sys.macro_output) {
+                *sys.macro_output << macros_ss.str();
+                sys.macro_output->close();
+            }
+
+            if (sys.macro_inject) {
+                amendFromStream(ci, macros_ss, "<macros>", sys, *S.get());
+            }
         }
 
         if (sys.template_output) {

--- a/src/c2ffi.cpp
+++ b/src/c2ffi.cpp
@@ -60,22 +60,21 @@ static void amendFromStream(clang::CompilerInstance &ci,
                             const std::string &name,
                             const c2ffi::config &sys,
                             clang::Sema &S) {
-  if (sys.verbose) {
-    ss.clear();
-    ss.seekg(0);
-    std::string line;
-    while (std::getline(ss, line)) {
-      std::cerr << name << ": " << line << std::endl;
+    if (sys.verbose) {
+        ss.clear();
+        ss.seekg(0);
+        std::string line;
+        while (std::getline(ss, line)) {
+            std::cerr << name << ": " << line << std::endl;
+        }
     }
-  }
 
-  std::string buf = ss.str();
+    std::string buf = ss.str();
 
-  clang::FileID mfid =
-      ci.getSourceManager().createFileID(std::unique_ptr<llvm::MemoryBuffer>(
-          llvm::MemoryBuffer::getMemBuffer(buf, name)));
+    clang::FileID mfid = ci.getSourceManager().createFileID(
+        std::unique_ptr<llvm::MemoryBuffer>(llvm::MemoryBuffer::getMemBuffer(buf, name)));
 
-  IncrementalParseAST(S, mfid, false, true);
+    IncrementalParseAST(S, mfid, false, true);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/include/c2ffi/ast.h
+++ b/src/include/c2ffi/ast.h
@@ -64,7 +64,7 @@ namespace c2ffi {
         void HandleDeclContext(const clang::DeclContext *dc,
                                const clang::NamedDecl *ns);
         void HandleNS(const clang::NamespaceDecl *ns);
-        void PostProcess();
+        void PostProcess(std::ostream& out);
 
         Decl* proc(const clang::Decl*, Decl*);
 
@@ -105,7 +105,7 @@ namespace c2ffi {
         Decl* make_decl(const clang::ObjCProtocolDecl *d, bool is_toplevel = true);
 
         void write_template(const clang::ClassTemplateSpecializationDecl *d,
-                            std::ofstream &out);
+                            std::ostream &out);
     };
 }
 

--- a/src/include/c2ffi/iparseast.h
+++ b/src/include/c2ffi/iparseast.h
@@ -1,14 +1,23 @@
-//===--- ParseAST.h - Define the ParseAST method ----------------*- C++ -*-===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-//
-//  This file defines the clang::ParseAST method.
-//
-//===----------------------------------------------------------------------===//
+/*  -*- c++ -*-
+
+    This file is part of c2ffi.
+
+    c2ffi is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    c2ffi is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with c2ffi.  If not, see <http://www.gnu.org/licenses/>.
+
+    This code mostly originates from clang, with some small modifications.
+    https://clang.llvm.org/
+*/
 
 #ifndef C2FFI_PARSE_PARSEAST_H
 #define C2FFI_PARSE_PARSEAST_H

--- a/src/include/c2ffi/iparseast.h
+++ b/src/include/c2ffi/iparseast.h
@@ -28,28 +28,9 @@
 namespace c2ffi {
   using namespace clang;
 
-  /// Parse the entire file specified, notifying the ASTConsumer as
-  /// the file is parsed.
-  ///
-  /// This operation inserts the parsed decls into the translation
-  /// unit held by Ctx.
-  ///
-  /// \param PrintStats Whether to print LLVM statistics related to parsing.
-  /// \param TUKind The kind of translation unit being parsed.
-  /// \param CompletionConsumer If given, an object to consume code completion
-  /// results.
-  /// \param SkipFunctionBodies Whether to skip parsing of function bodies.
-  /// This option can be used, for example, to speed up searches for
-  /// declarations/definitions when indexing.
-  void IncrementalParseAST(Preprocessor &pp, ASTConsumer *C,
-                ASTContext &Ctx, bool PrintStats = false,
-                TranslationUnitKind TUKind = TU_Complete,
-                CodeCompleteConsumer *CompletionConsumer = nullptr,
-                bool SkipFunctionBodies = false);
-
-  /// Parse the main file known to the preprocessor, producing an
+  /// Parse the extra file known to the preprocessor, amending an
   /// abstract syntax tree.
-  void IncrementalParseAST(Sema &S, bool PrintStats = false,
+  void IncrementalParseAST(Sema &S, FileID &fid, bool PrintStats = false,
                 bool SkipFunctionBodies = false);
 
 }  // end namespace clang

--- a/src/include/c2ffi/iparseast.h
+++ b/src/include/c2ffi/iparseast.h
@@ -1,0 +1,48 @@
+//===--- ParseAST.h - Define the ParseAST method ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the clang::ParseAST method.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef C2FFI_PARSE_PARSEAST_H
+#define C2FFI_PARSE_PARSEAST_H
+
+#include "clang/Basic/LangOptions.h"
+#include <clang/Sema/Sema.h>
+
+namespace c2ffi {
+  using namespace clang;
+
+  /// Parse the entire file specified, notifying the ASTConsumer as
+  /// the file is parsed.
+  ///
+  /// This operation inserts the parsed decls into the translation
+  /// unit held by Ctx.
+  ///
+  /// \param PrintStats Whether to print LLVM statistics related to parsing.
+  /// \param TUKind The kind of translation unit being parsed.
+  /// \param CompletionConsumer If given, an object to consume code completion
+  /// results.
+  /// \param SkipFunctionBodies Whether to skip parsing of function bodies.
+  /// This option can be used, for example, to speed up searches for
+  /// declarations/definitions when indexing.
+  void IncrementalParseAST(Preprocessor &pp, ASTConsumer *C,
+                ASTContext &Ctx, bool PrintStats = false,
+                TranslationUnitKind TUKind = TU_Complete,
+                CodeCompleteConsumer *CompletionConsumer = nullptr,
+                bool SkipFunctionBodies = false);
+
+  /// Parse the main file known to the preprocessor, producing an
+  /// abstract syntax tree.
+  void IncrementalParseAST(Sema &S, bool PrintStats = false,
+                bool SkipFunctionBodies = false);
+
+}  // end namespace clang
+
+#endif

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -35,7 +35,7 @@ namespace c2ffi {
     typedef std::vector<std::string> IncludeVector;
 
     struct config {
-        config() : od(NULL), macro_output(NULL),
+        config() : od(NULL), macro_output(false),
                    template_output(NULL),
                    std(clang::LangStandard::lang_unspecified),
                    preprocess_only(false),

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -36,11 +36,12 @@ namespace c2ffi {
 
     struct config {
         config() : od(NULL), macro_output(false),
-                   template_output(NULL),
+                   template_output(false),
                    std(clang::LangStandard::lang_unspecified),
                    preprocess_only(false),
                    with_macro_defs(false),
                    nostdinc(false),
+                   verbose(false),
                    wchar_size(0),
                    error_limit(0)
         { }
@@ -51,7 +52,7 @@ namespace c2ffi {
 
         std::ostream  *output;
         bool macro_output;
-        std::ofstream *template_output;
+        bool template_output;
 
         std::string c2ffi_binpath;
         std::string filename;
@@ -68,6 +69,7 @@ namespace c2ffi {
         bool fail_on_error;
         bool warn_as_error;
         bool nostdinc;
+        bool verbose;
 
         int wchar_size;
 

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -50,7 +50,7 @@ namespace c2ffi {
         OutputDriver *od;
 
         std::ostream  *output;
-        std::ofstream *macro_output;
+        bool macro_output;
         std::ofstream *template_output;
 
         std::string c2ffi_binpath;

--- a/src/include/c2ffi/opt.h
+++ b/src/include/c2ffi/opt.h
@@ -35,7 +35,8 @@ namespace c2ffi {
     typedef std::vector<std::string> IncludeVector;
 
     struct config {
-        config() : od(NULL), macro_output(false),
+        config() : od(NULL), macro_output(nullptr),
+                   macro_inject(false),
                    template_output(false),
                    std(clang::LangStandard::lang_unspecified),
                    preprocess_only(false),
@@ -51,7 +52,8 @@ namespace c2ffi {
         OutputDriver *od;
 
         std::ostream  *output;
-        bool macro_output;
+        std::ofstream  *macro_output;
+        bool macro_inject;
         bool template_output;
 
         std::string c2ffi_binpath;

--- a/src/iparseast.cpp
+++ b/src/iparseast.cpp
@@ -1,15 +1,23 @@
-//===--- ParseAST.cpp - Provide the clang::ParseAST method ----------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-//
-// This file implements the clang::ParseAST method.
-//
-//===----------------------------------------------------------------------===//
+/*  -*- c++ -*-
 
+    This file is part of c2ffi.
+
+    c2ffi is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    c2ffi is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with c2ffi.  If not, see <http://www.gnu.org/licenses/>.
+
+    This code mostly originates from clang, with some small modifications.
+    https://clang.llvm.org/
+*/
 #include <clang/Parse/ParseAST.h>
 #include <clang/AST/ASTConsumer.h>
 #include <clang/AST/ASTContext.h>

--- a/src/iparseast.cpp
+++ b/src/iparseast.cpp
@@ -1,0 +1,195 @@
+//===--- ParseAST.cpp - Provide the clang::ParseAST method ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the clang::ParseAST method.
+//
+//===----------------------------------------------------------------------===//
+
+#include <clang/Parse/ParseAST.h>
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/ExternalASTSource.h>
+#include <clang/AST/Stmt.h>
+#include <clang/Parse/ParseDiagnostic.h>
+#include <clang/Parse/Parser.h>
+#include <clang/Sema/CodeCompleteConsumer.h>
+#include <clang/Sema/SemaConsumer.h>
+#include <clang/Sema/TemplateInstCallback.h>
+#include <llvm/Support/CrashRecoveryContext.h>
+#include <llvm/Support/TimeProfiler.h>
+#include <cstdio>
+#include <memory>
+#include "c2ffi/iparseast.h"
+
+using namespace clang;
+
+namespace {
+
+/// Resets LLVM's pretty stack state so that stack traces are printed correctly
+/// when there are nested CrashRecoveryContexts and the inner one recovers from
+/// a crash.
+class ResetStackCleanup
+    : public llvm::CrashRecoveryContextCleanupBase<ResetStackCleanup,
+                                                   const void> {
+public:
+  ResetStackCleanup(llvm::CrashRecoveryContext *Context, const void *Top)
+      : llvm::CrashRecoveryContextCleanupBase<ResetStackCleanup, const void>(
+            Context, Top) {}
+  void recoverResources() override {
+    llvm::RestorePrettyStackState(resource);
+  }
+};
+
+/// If a crash happens while the parser is active, an entry is printed for it.
+class PrettyStackTraceParserEntry : public llvm::PrettyStackTraceEntry {
+  const Parser &P;
+public:
+  PrettyStackTraceParserEntry(const Parser &p) : P(p) {}
+  void print(raw_ostream &OS) const override;
+};
+
+/// If a crash happens while the parser is active, print out a line indicating
+/// what the current token is.
+void PrettyStackTraceParserEntry::print(raw_ostream &OS) const {
+  const Token &Tok = P.getCurToken();
+  if (Tok.is(tok::eof)) {
+    OS << "<eof> parser at end of file\n";
+    return;
+  }
+
+  if (Tok.getLocation().isInvalid()) {
+    OS << "<unknown> parser at unknown location\n";
+    return;
+  }
+
+  const Preprocessor &PP = P.getPreprocessor();
+  Tok.getLocation().print(OS, PP.getSourceManager());
+  if (Tok.isAnnotation()) {
+    OS << ": at annotation token\n";
+  } else {
+    // Do the equivalent of PP.getSpelling(Tok) except for the parts that would
+    // allocate memory.
+    bool Invalid = false;
+    const SourceManager &SM = P.getPreprocessor().getSourceManager();
+    unsigned Length = Tok.getLength();
+    const char *Spelling = SM.getCharacterData(Tok.getLocation(), &Invalid);
+    if (Invalid) {
+      OS << ": unknown current parser token\n";
+      return;
+    }
+    OS << ": current parser token '" << StringRef(Spelling, Length) << "'\n";
+  }
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Public interface to the file
+//===----------------------------------------------------------------------===//
+
+/// ParseAST - Parse the entire file specified, notifying the ASTConsumer as
+/// the file is parsed.  This inserts the parsed decls into the translation unit
+/// held by Ctx.
+///
+void c2ffi::IncrementalParseAST(Preprocessor &PP, ASTConsumer *Consumer,
+                     ASTContext &Ctx, bool PrintStats,
+                     TranslationUnitKind TUKind,
+                     CodeCompleteConsumer *CompletionConsumer,
+                     bool SkipFunctionBodies) {
+
+  std::unique_ptr<Sema> S(
+      new Sema(PP, Ctx, *Consumer, TUKind, CompletionConsumer));
+
+  // Recover resources if we crash before exiting this method.
+  llvm::CrashRecoveryContextCleanupRegistrar<Sema> CleanupSema(S.get());
+
+  IncrementalParseAST(*S.get(), PrintStats, SkipFunctionBodies);
+}
+
+void c2ffi::IncrementalParseAST(Sema &S, bool PrintStats, bool SkipFunctionBodies) {
+  // Collect global stats on Decls/Stmts (until we have a module streamer).
+  if (PrintStats) {
+    Decl::EnableStatistics();
+    Stmt::EnableStatistics();
+  }
+
+  // Also turn on collection of stats inside of the Sema object.
+  bool OldCollectStats = PrintStats;
+  std::swap(OldCollectStats, S.CollectStats);
+
+  // Initialize the template instantiation observer chain.
+  // FIXME: See note on "finalize" below.
+  initialize(S.TemplateInstCallbacks, S);
+
+  ASTConsumer *Consumer = &S.getASTConsumer();
+
+  std::unique_ptr<Parser> ParseOP(
+      new Parser(S.getPreprocessor(), S, SkipFunctionBodies));
+  Parser &P = *ParseOP.get();
+
+  llvm::CrashRecoveryContextCleanupRegistrar<const void, ResetStackCleanup>
+      CleanupPrettyStack(llvm::SavePrettyStackState());
+  PrettyStackTraceParserEntry CrashInfo(P);
+
+  // Recover resources if we crash before exiting this method.
+  llvm::CrashRecoveryContextCleanupRegistrar<Parser>
+    CleanupParser(ParseOP.get());
+
+  // ParseAST was copied wholesale to change just this one line that was
+  // breaking the incremental parse. This switches to the new file ID rather
+  // than entering the main file again, which re-initializes some things that
+  // shouldn't be.
+  auto &SM = S.getSourceManager();
+  S.getPreprocessor().EnterSourceFile(SM.getMainFileID(), nullptr,
+                                      SM.getLocForStartOfFile(SM.getMainFileID()));
+  ExternalASTSource *External = S.getASTContext().getExternalSource();
+  if (External)
+    External->StartTranslationUnit(Consumer);
+
+  // If a PCH through header is specified that does not have an include in
+  // the source, or a PCH is being created with #pragma hdrstop with nothing
+  // after the pragma, there won't be any tokens or a Lexer.
+  bool HaveLexer = S.getPreprocessor().getCurrentLexer();
+
+  if (HaveLexer) {
+    llvm::TimeTraceScope TimeScope("Frontend");
+    P.Initialize();
+    Parser::DeclGroupPtrTy ADecl;
+    for (bool AtEOF = P.ParseFirstTopLevelDecl(ADecl); !AtEOF;
+         AtEOF = P.ParseTopLevelDecl(ADecl)) {
+      // If we got a null return and something *was* parsed, ignore it.  This
+      // is due to a top-level semicolon, an action override, or a parse error
+      // skipping something.
+      if (ADecl && !Consumer->HandleTopLevelDecl(ADecl.get()))
+        return;
+    }
+  }
+
+  // Process any TopLevelDecls generated by #pragma weak.
+  for (Decl *D : S.WeakTopLevelDecls())
+    Consumer->HandleTopLevelDecl(DeclGroupRef(D));
+
+  Consumer->HandleTranslationUnit(S.getASTContext());
+
+  // Finalize the template instantiation observer chain.
+  // FIXME: This (and init.) should be done in the Sema class, but because
+  // Sema does not have a reliable "Finalize" function (it has a
+  // destructor, but it is not guaranteed to be called ("-disable-free")).
+  // So, do the initialization above and do the finalization here:
+  finalize(S.TemplateInstCallbacks, S);
+
+  std::swap(OldCollectStats, S.CollectStats);
+  if (PrintStats) {
+    llvm::errs() << "\nSTATISTICS:\n";
+    if (HaveLexer) P.getActions().PrintStats();
+    S.getASTContext().PrintStats();
+    Decl::PrintStats();
+    Stmt::PrintStats();
+    Consumer->PrintStats();
+  }
+}

--- a/src/iparseast.cpp
+++ b/src/iparseast.cpp
@@ -155,6 +155,8 @@ void c2ffi::IncrementalParseAST(Sema &S, bool PrintStats, bool SkipFunctionBodie
   auto &SM = S.getSourceManager();
   S.getPreprocessor().EnterSourceFile(SM.getMainFileID(), nullptr,
                                       SM.getLocForStartOfFile(SM.getMainFileID()));
+  // Clear the old translation unit context ... or something
+  S.CurContext = nullptr;
   ExternalASTSource *External = S.getASTContext().getExternalSource();
   if (External)
     External->StartTranslationUnit(Consumer);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -29,7 +29,7 @@
 #include "c2ffi.h"
 #include "c2ffi/opt.h"
 
-static char short_opt[] = "I:i:D:M:o:hN:x:A:T:E";
+static char short_opt[] = "I:i:D:Mo:hN:x:A:T:E";
 
 enum {
     WITH_MACRO_DEFS = CHAR_MAX+1,
@@ -48,7 +48,7 @@ static struct option options[] = {
     { "sys-include", required_argument, 0, 'i' },
     { "driver",      required_argument, 0, 'D' },
     { "help",        no_argument,       0, 'h' },
-    { "macro-file",  required_argument, 0, 'M' },
+    { "macro-file",  no_argument,       0, 'M' },
     { "output",      required_argument, 0, 'o' },
     { "namespace",   required_argument, 0, 'N' },
     { "lang",        required_argument, 0, 'x' },
@@ -88,15 +88,7 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
 
         switch(o) {
             case 'M': {
-                if(config.macro_output) {
-                    std::cerr << "Error: You may only specify one macro file"
-                              << std::endl;
-                    exit(1);
-                }
-
-                std::ofstream *of = new std::ofstream;
-                of->open(optarg);
-                config.macro_output = of;
+                config.macro_output = true;
                 break;
             }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -48,7 +48,7 @@ static struct option options[] = {
     { "sys-include", required_argument, 0, 'i' },
     { "driver",      required_argument, 0, 'D' },
     { "help",        no_argument,       0, 'h' },
-    { "macro-file",  no_argument,       0, 'M' },
+    { "macros",      no_argument,       0, 'M' },
     { "output",      required_argument, 0, 'o' },
     { "namespace",   required_argument, 0, 'N' },
     { "lang",        required_argument, 0, 'x' },
@@ -257,8 +257,9 @@ void usage(void) {
          << OutputDrivers[0].name << ")\n"
         "\n"
         "      -o, --output         Specify an output file (default: stdout)\n"
-        "      -M, --macro-file     Specify a file for macro definition output\n"
+        "      -M, --macros         Enable generation of constants from macros\n"
         "      --with-macro-defs    Also include #defines for macro definitions\n"
+        "      -T, --templates      Enable automatic generation of template specializations\n"
         "\n"
         "      -N, --namespace      Specify target namespace/package/etc\n"
         "\n"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -29,7 +29,7 @@
 #include "c2ffi.h"
 #include "c2ffi/opt.h"
 
-static char short_opt[] = "I:i:D:Mo:hN:x:A:T:E";
+static char short_opt[] = "I:i:D:Mo:hN:x:A:TEv";
 
 enum {
     WITH_MACRO_DEFS = CHAR_MAX+1,
@@ -53,7 +53,7 @@ static struct option options[] = {
     { "namespace",   required_argument, 0, 'N' },
     { "lang",        required_argument, 0, 'x' },
     { "arch",        required_argument, 0, 'A' },
-    { "templates",   required_argument, 0, 'T' },
+    { "templates",   no_argument,       0, 'T' },
     { "std",         required_argument, 0, 'S' },
     { "with-macro-defs", no_argument,   0, WITH_MACRO_DEFS },
     { "declspec",        no_argument,   0, DECLSPEC        },
@@ -87,6 +87,10 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
             break;
 
         switch(o) {
+            case 'v': {
+                config.verbose = true;
+            }
+
             case 'M': {
                 config.macro_output = true;
                 break;
@@ -136,14 +140,7 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
                 break;
 
             case 'T':
-                if(config.template_output) {
-                    std::cerr << "Error: you may only specify one template output file"
-                              << std::endl;
-                    exit(1);
-                }
-
-                config.template_output = new std::ofstream;
-                config.template_output->open(optarg);
+                config.template_output = true;
                 break;
 
             case 'E':

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -49,6 +49,7 @@ static struct option options[] = {
     { "driver",      required_argument, 0, 'D' },
     { "help",        no_argument,       0, 'h' },
     { "macro-file",  required_argument, 0, 'M' },
+    { "macro-append",no_argument,       0, 'n' },
     { "output",      required_argument, 0, 'o' },
     { "namespace",   required_argument, 0, 'N' },
     { "lang",        required_argument, 0, 'x' },
@@ -89,6 +90,7 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
         switch(o) {
             case 'v': {
                 config.verbose = true;
+                break;
             }
 
             case 'M': {
@@ -270,7 +272,9 @@ void usage(void) {
          << OutputDrivers[0].name << ")\n"
         "\n"
         "      -o, --output         Specify an output file (default: stdout)\n"
-        "      -M, --macros         Enable generation of constants from macros\n"
+        "      -M, --macro-file     Enable generation of constants from macros into specified file\n"
+        "      -m, --macro-append   Enable generation of constants from macros internally appended\n"
+        "                           to input\n"
         "      --with-macro-defs    Also include #defines for macro definitions\n"
         "      -T, --templates      Enable automatic generation of template specializations\n"
         "\n"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -29,7 +29,7 @@
 #include "c2ffi.h"
 #include "c2ffi/opt.h"
 
-static char short_opt[] = "I:i:D:Mo:hN:x:A:TEv";
+static char short_opt[] = "I:i:D:M:mo:hN:x:A:TEv";
 
 enum {
     WITH_MACRO_DEFS = CHAR_MAX+1,
@@ -48,7 +48,7 @@ static struct option options[] = {
     { "sys-include", required_argument, 0, 'i' },
     { "driver",      required_argument, 0, 'D' },
     { "help",        no_argument,       0, 'h' },
-    { "macros",      no_argument,       0, 'M' },
+    { "macro-file",  required_argument, 0, 'M' },
     { "output",      required_argument, 0, 'o' },
     { "namespace",   required_argument, 0, 'N' },
     { "lang",        required_argument, 0, 'x' },
@@ -92,7 +92,20 @@ void c2ffi::process_args(config &config, int argc, char *argv[]) {
             }
 
             case 'M': {
-                config.macro_output = true;
+                if (config.macro_output) {
+                    std::cerr << "Error: You may only specify one macro file" << std::endl;
+
+                    exit(1);
+                }
+
+                std::ofstream *of = new std::ofstream;
+                of->open(optarg);
+                config.macro_output = of;
+                break;
+            }
+
+            case 'm': {
+                config.macro_inject = true;
                 break;
             }
 


### PR DESCRIPTION
Instead of generating code to a file, and having the user run c2ffi a second time with the additional code, this patch writes the extra code to a buffer and crams it through the parser after the main input file, eliminating the extra step and associated file I/O. In order to pull this off I ended up having to copy the clang ParseAST code just to change one line.

The PR also ignores macros with curly braces. I had noticed that such macros can sometimes cause valid constants to be dropped, and since the order of the generated constants isn't deterministic for some reason (??) you also have no idea which constants it will erase.

Please note that this breaks backwards compatibility of the command line interface, since the -T and -M options no longer need a path to output to.