### PR TITLE
The spec file is missing the value for a string created with #define

### DIFF
--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -253,7 +253,7 @@ Decl* C2FFIASTConsumer::make_decl(const clang::VarDecl* d, bool is_toplevel)
                         {
                             is_string = true;
 
-                            if(s->isUTF8()) {
+                            if(s->isOrdinary() || s->isUTF8()) {
                                 value = s->getString();
                             } else if(s->getCharByteWidth() == 2) {
                                 llvm::StringRef bytes = s->getBytes();


### PR DESCRIPTION
Hello,

I ran into a problem where the generated spec file didn't have the value for a #define with a string. For example, `#define SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER "SDL.texture.create.format"` would only have the name, but not the value in the spec file. 

I noticed that it did work with an older llvm-12.x branch and then found out that isAscii() was renamed to isOrdinary(): https://github.com/llvm/llvm-project/commit/a9a60f20e6cc80855864b8f559073bc31f34554b 

Making use of isOrdinary() does provide the value for the #define in the spec file. Thanks for creating c2ffi because it really does make it easier to interface with other libraries.

