### PR TITLE
Apple Silicon support

### DIFF
--- a/CMake/cxx_features.cmake
+++ b/CMake/cxx_features.cmake
@@ -40,7 +40,7 @@
 
 cmake_minimum_required(VERSION 3.11)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   if(WIN32 AND NOT MINGW)
     function(__cxx_feature_process)
       __cxx_feature_clang_cl(${ARGN})

--- a/src/AST.cpp
+++ b/src/AST.cpp
@@ -242,8 +242,8 @@ Decl* C2FFIASTConsumer::make_decl(const clang::VarDecl* d, bool is_toplevel)
     if(d->hasInit()) {
         if(!d->getType()->isDependentType()) {
             clang::EvaluatedStmt* stmt = d->ensureEvaluatedStmt();
-            clang::Expr*          e    = clang::cast<clang::Expr*>(stmt->Value);
-            if(!e->isValueDependent() && ((v = d->evaluateValue()) || (v = d->getEvaluatedValue()))) {
+            const clang::Expr*    e    = d->getInit();
+            if(e && !e->isValueDependent() && ((v = d->evaluateValue()) || (v = d->getEvaluatedValue()))) {
                 if(v->isLValue()) {
                     clang::APValue::LValueBase base = v->getLValueBase();
                     if(!base.isNull() && base.is<const clang::Expr*>()) {


### PR DESCRIPTION
I needed to compile this with MacBook M4 so here are the changes I had to make in order to make it compile.  This was a vibe coding exercise so I can't really judge if the changes are appropriate or not. I can just confirm that I successfully compiled the project and used it.

# Summary

  Added Apple Silicon (ARM64 macOS) support with two key changes:

  1. CMake/cxx_features.cmake

  - Extended compiler detection to recognize AppleClang in addition to regular Clang
  - This ensures proper C++ feature detection on macOS systems using Apple's Clang variant

  2. src/AST.cpp (line ~245)

  - Fixed initialization value evaluation in make_decl() function:
    - Changed from casting stmt->Value to using d->getInit() directly for safer expression
   retrieval
    - Added null check for the expression before evaluation
    - Corrected const-correctness (const clang::Expr* instead of clang::Expr*)
  - This prevents potential crashes when evaluating variable initializers on Apple Silicon

  These changes enable c2ffi to compile and run correctly on ARM64 macOS systems while
  maintaining compatibility with other platforms.